### PR TITLE
Formatted returns for docs-core

### DIFF
--- a/src/documenter.ts
+++ b/src/documenter.ts
@@ -369,13 +369,15 @@ export class Documenter implements vs.Disposable {
         if (utils.findNonVoidReturnInCurrentScope(node) || (node.type && node.type.getText() !== "void")) {
             sb.append("@returns");
             if (includeTypes() && node.type) {
-                sb.append(" " + utils.formatTypeName(node.type.getText()));
+                sb.append(` {${utils.formatTypeName(node.type.getText())}}`);
             }
             else if (includeTypes() && inferTypes()) {
-                sb.append(" " + this._inferReturnTypeFromName(node.name.getText()));
+                sb.append(` {${this._inferReturnTypeFromName(node.name.getText())}}`);
+            } else if (includeTypes()) {
+                sb.append(" {any}");
             }
 
-            sb.append(" ");
+            sb.append(" - ");
             sb.appendSnippetTabstop();
 
             sb.appendLine();


### PR DESCRIPTION
The types would have been output if the code could have sensed them, but needed to be in `{}`.  This is now done and a `-` character is added to the end for a returns description.  If includeTypes is set, and type cannot be found or infered, `{any}` will be included for `@returns`.